### PR TITLE
refactor: realocando getProducts para routers

### DIFF
--- a/src/controllers/products.controllers.js
+++ b/src/controllers/products.controllers.js
@@ -1,0 +1,10 @@
+import {collectionProducts} from "../database/database.js";
+
+export async function getProducts(req,res) {
+    try {
+        const products = await collectionProducts.find().toArray()
+        res.send(products);
+    } catch (error) {
+        res.send(error);
+    }
+}

--- a/src/controllers/users.controller.js
+++ b/src/controllers/users.controller.js
@@ -1,4 +1,4 @@
-import { collectionUsers, collectionSessions, collectionProducts } from "../database/database.js";
+import { collectionUsers, collectionSessions } from "../database/database.js";
 
 export async function postSingUp(req, res) {
 
@@ -44,12 +44,4 @@ export async function deleteGoOut(req, res) {
     }
 
 
-}
-export async function getProducts(req,res) {
-    try {
-        const products = await collectionProducts.find().toArray()
-        res.send(products);
-    } catch (error) {
-        res.send(error);
-    }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -3,11 +3,13 @@ import express from 'express';
 import cors from 'cors';
 import joi from 'joi'
 import usersRouters from "./routers/users.routers.js"
+import products from "./routers/products.routers.js"
 
 const app = express();
 app.use(cors());
 app.use(express.json());
 app.use(usersRouters);
+app.use(products);
 
 export const validateUsers = joi.object({
     name: joi.string().min(3).max(30).required(),

--- a/src/routers/products.routers.js
+++ b/src/routers/products.routers.js
@@ -1,0 +1,9 @@
+import { Router } from "express";
+
+import { getProducts } from "../controllers/products.controllers.js";
+
+const router = Router();
+
+router.get("/products", getProducts );
+
+export default router;

--- a/src/routers/users.routers.js
+++ b/src/routers/users.routers.js
@@ -1,6 +1,6 @@
 import { Router } from "express";
 
-import { postSingUp, postSingIn, deleteGoOut, getProducts } from "../controllers/users.controller.js"
+import { postSingUp, postSingIn, deleteGoOut } from "../controllers/users.controller.js"
 import { singUpMD } from "../middleware/singUp.middleware.js";
 import { singInMD } from "../middleware/singIn.middleware.js";
 
@@ -9,6 +9,5 @@ const router = Router();
 router.post("/sing-up", singUpMD, postSingUp);
 router.post("/sing-in", singInMD, postSingIn);
 router.delete( "/go-out", deleteGoOut );
-router.get("/products", getProducts )
 
 export default router;


### PR DESCRIPTION
Fiz alteração do local onde fica o getProducts que ontem só tinha jogado em qualquer lugar para poder configurar a conexão dos deploys